### PR TITLE
Fixes #5 - Adicionando e removendo membros do ministério

### DIFF
--- a/src/main/java/converters/MembroConverter.java
+++ b/src/main/java/converters/MembroConverter.java
@@ -1,10 +1,7 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package converters;
 
+import java.io.Serializable;
+import javax.enterprise.context.SessionScoped;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
@@ -15,16 +12,14 @@ import org.itbparnamirim.kadosh6.data.MembroDAO;
 import org.itbparnamirim.kadosh6.model.Membro;
 
 @Named
+@SessionScoped
 @FacesConverter(value = "membroConverter")
-public class MembroConverter implements Converter{
+public class MembroConverter implements Converter, Serializable{
 
     @Inject MembroDAO membroDAO;
     
     @Override
     public Object getAsObject(FacesContext context, UIComponent component, String value) {
-        if (value == null){
-            System.out.println("VALUE NULO");
-        }
         if (membroDAO == null){
             System.out.println("MEMBRO DAO NULO");
         }
@@ -37,5 +32,4 @@ public class MembroConverter implements Converter{
         Membro membro = (Membro) value;
         return String.valueOf(membro.getId());
     }
-    
 }

--- a/src/main/java/org/itbparnamirim/kadosh6/beans/MinisterioMB.java
+++ b/src/main/java/org/itbparnamirim/kadosh6/beans/MinisterioMB.java
@@ -4,9 +4,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.PostConstruct;
+import javax.enterprise.context.SessionScoped;
 //import javax.enterprise.context.SessionScoped;
-import javax.faces.bean.ManagedBean;
-import javax.faces.bean.SessionScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.itbparnamirim.kadosh6.data.MembroDAO;
@@ -19,7 +18,7 @@ import org.itbparnamirim.kadosh6.model.Ministerio;
  * @author Geraldo
  */
 @SessionScoped
-@ManagedBean
+@Named
 public class MinisterioMB implements Serializable {
 
     private Ministerio ministerio = new Ministerio();
@@ -27,14 +26,12 @@ public class MinisterioMB implements Serializable {
     private Membro membroSelecionado = new Membro();
     private List<Ministerio> ministerios = new ArrayList<>();
     
-    
     @Inject
     MinisterioDAO ministerioDAO;
 
     @Inject
     MembroDAO membroDAO;
     
-    @PostConstruct
     public void carregarLista() {
         this.ministerios = ministerioDAO.list();
     }
@@ -130,15 +127,17 @@ public class MinisterioMB implements Serializable {
     }
     
     public String adicionarMembro(){
-        if (membroSelecionado == null || membroSelecionado.getId() == null){
-            System.out.println("MEMBRO NAO FOI SELECIONADO");
-            return "/pages/dashboardAdmin.xhtml"+ManagedBeanUtil.REDIRECT;
-        }
         this.ministerio.adicionarMembro(membroSelecionado);
         ministerioDAO.save(ministerio);
         ManagedBeanUtil.refresh();
+        membroSelecionado = null;
         return "/pages/ministerio/detalharMinisterio.xhtml"+ManagedBeanUtil.REDIRECT;
     }
     
-    
+    public String removerMembro(Membro membro){
+        this.ministerio.removerMembro(membro);
+        ministerioDAO.save(ministerio);
+         ManagedBeanUtil.refresh();
+        return "/pages/ministerio/detalharMinisterio.xhtml"+ManagedBeanUtil.REDIRECT;
+    }
 }

--- a/src/main/webapp/WEB-INF/faces-config.xml
+++ b/src/main/webapp/WEB-INF/faces-config.xml
@@ -8,5 +8,9 @@
             <base-name>/Bundle</base-name>
             <var>bundle</var>
         </resource-bundle>
+        <converter>
+            <converter-id>converter.MembroConverter</converter-id>
+            <converter-class>converters.MembroConverter</converter-class>
+        </converter>
     </application>
 </faces-config>

--- a/src/main/webapp/pages/ministerio/detalharMinisterio.xhtml
+++ b/src/main/webapp/pages/ministerio/detalharMinisterio.xhtml
@@ -47,11 +47,14 @@
                     <h:form id="autocompleteMembro">
                         <p:outputLabel value="Membro:" />
                         <p:autoComplete id="aut" value="#{ministerioMB.membroSelecionado}" completeMethod="#{ministerioMB.completeMembroAutoComplete}"
-                                        var="membro" itemLabel="#{membro.nome}" itemValue="#{membro}" converter="omnifaces.SelectItemsConverter" 
-                                        forceSelection="true" dropdown="true"/>
+                                        var="membro" itemLabel="#{membro.nome}" itemValue="#{membro}" 
+                                        forceSelection="true" dropdown="true">
+                            <f:converter converterId="converter.MembroConverter" />
+                        </p:autoComplete>
                         <p:commandButton value="Adicionar Membro" action="#{ministerioMB.adicionarMembro()}"/>
-
-                        <p:panel>
+                    </h:form>
+                    <p:panel>
+                        <h:form>
                             <p:dataTable resizableColumns="true" var="membro" value="#{ministerioMB.ministerio.membrosMinisterio}">
                                 <p:column headerText="Nome">
                                     <h:outputText value="#{membro.nome}"/>
@@ -62,10 +65,21 @@
                                 <p:column headerText="E-mail">
                                     <h:outputText value="#{membro.email}"/>
                                 </p:column>
+                                <p:column>
+                                    <p:commandButton icon="ui-icon-trash" title="Remover membro" action="#{ministerioMB.removerMembro(membro)}">
+                                        <p:confirm header="Confirmação" message="Tem certeza que deseja remover o(a) #{membro.nome} desse ministério?" icon="ui-icon-alert"/>
+                                    </p:commandButton>
+
+                                    <p:confirmDialog global="true" showEffect="fade" hideEffect="fade">
+                                        <p:commandButton value="Sim" type="button" styleClass="ui-confirmdialog-yes" icon="ui-icon-check"/>
+                                        <p:commandButton value="Não" type="button" styleClass="ui-confirmdialog-no" icon="ui-icon-close"/>
+                                    </p:confirmDialog>
+                                </p:column>
                             </p:dataTable>
                             <p:commandButton value="Voltar" onclick="history.go(-1)"/>
-                        </p:panel>
-                    </h:form>
+                        </h:form>
+                    </p:panel>
+
                 </p:layoutUnit>
 
             </p:layout>


### PR DESCRIPTION
Foram necessárias algumas correções no projeto para que a associação de membros com ministérios funcionasse corretamente. O problema inicial estava no autocomplete, que não estava retornando o membro selecionado para ser adicionado no ministério. Para consertar, foi necessário acrescentar o seguinte trecho no arquivo faces-config.xml:

```
<converter-id>converter.MembroConverter</converter-id>
<converter-class>converters.MembroConverter</converter-class>
```

E dentro do elemento <p:autocomplete>:
```
`<f:converter converterId="converter.MembroConverter" />``
```
Com isso, o MembroConverter pôde ser invocado. Porém, o MembroDAO estava retornando nulo, pois o CDI não estava conseguindo criar uma instância para o atributo. Acredito que a causa seja o fato do JSF não estar controlando o ciclo de vida do Converter. Isso foi corrigido colocando a anotação @SessionScoped.